### PR TITLE
Feat/1 create organisation api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 organization_api-*.tar
 
+/config/.env.exs

--- a/README.md
+++ b/README.md
@@ -1,18 +1,32 @@
 # OrganizationApi
 
-To start your Phoenix server:
+# OrganizationApi
 
-  * Run `mix setup` to install and setup dependencies
-  * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
+## Usage
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+To run the application, follow these steps:
 
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+1. Clone the repository.
+2. Install dependencies with `mix deps.get`.
+3. Create a `.env.exs` environment file and add your database username and password in the format provided in `sample.env.exs`
+4. Run `mix ecto.create` for creating the databases needed and run migration using command `mix ecto.migrate`.
+4. Start the Phoenix server with `mix phx.server`.Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-## Learn more
+The application should now be running, and you can make requests to the endpoints using tools like Postman or cURL.
 
-  * Official website: https://www.phoenixframework.org/
-  * Guides: https://hexdocs.pm/phoenix/overview.html
-  * Docs: https://hexdocs.pm/phoenix
-  * Forum: https://elixirforum.com/c/phoenix-forum
-  * Source: https://github.com/phoenixframework/phoenix
+## Routes
+
+The following routes are available:
+- `GET /api/organizations`: Lists all organizations.
+- `POST /api/organizations`: Creates a new organization.
+- `GET /api/organizations/:id`: Retrieves a specific organization.
+- `PUT /api/organizations/:id`: Updates an existing organization.
+- `DELETE /api/organizations/:id`: Deletes an existing organization.
+
+## Testing
+
+You can run the tests with the following command:
+
+```
+mix test
+```

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,10 @@
 # General application configuration
 import Config
 
+if config_env() in [:dev, :test] do
+  import_config ".env.exs"
+end
+
 config :organization_api,
   ecto_repos: [OrganizationApi.Repo],
   generators: [timestamp_type: :utc_datetime, binary_id: true]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,10 @@ import Config
 
 # Configure your database
 config :organization_api, OrganizationApi.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "organization_api_dev",
+  username: System.get_env("POSTGRES_USERNAME"),
+  password: System.get_env("POSTGRES_PASSWORD"),
+  hostname: System.get_env("POSTGRES_HOSTNAME"),
+  database: System.get_env("POSTGRES_DEV_DATABASE"),
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,8 +4,8 @@ import Config
 config :organization_api, OrganizationApi.Repo,
   username: System.get_env("POSTGRES_USERNAME"),
   password: System.get_env("POSTGRES_PASSWORD"),
-  hostname: System.get_env("POSTGRES_HOSTNAME"),
-  database: System.get_env("POSTGRES_DEV_DATABASE"),
+  hostname: "localhost",
+  database: "organization_api_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/sample.env.exs
+++ b/config/sample.env.exs
@@ -1,0 +1,2 @@
+System.put_env("POSTGRES_USERNAME", "your_username_here")
+System.put_env("POSTGRES_PASSWORD", "your_password_here")

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,10 +6,10 @@ import Config
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :organization_api, OrganizationApi.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "organization_api_test#{System.get_env("MIX_TEST_PARTITION")}",
+  username: System.get_env("POSTGRES_USERNAME"),
+  password: System.get_env("POSTGRES_PASSWORD"),
+  hostname: System.get_env("POSTGRES_HOSTNAME"),
+  database: "#{System.get_env("POSTGRES_TEST_DATABASE")}#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,8 +8,8 @@ import Config
 config :organization_api, OrganizationApi.Repo,
   username: System.get_env("POSTGRES_USERNAME"),
   password: System.get_env("POSTGRES_PASSWORD"),
-  hostname: System.get_env("POSTGRES_HOSTNAME"),
-  database: "#{System.get_env("POSTGRES_TEST_DATABASE")}#{System.get_env("MIX_TEST_PARTITION")}",
+  hostname: "localhost",
+  database: "organization_api_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 

--- a/lib/organization_api/organizations.ex
+++ b/lib/organization_api/organizations.ex
@@ -1,0 +1,104 @@
+defmodule OrganizationApi.Organizations do
+  @moduledoc """
+  The Organizations context.
+  """
+
+  import Ecto.Query, warn: false
+  alias OrganizationApi.Repo
+
+  alias OrganizationApi.Organizations.Organization
+
+  @doc """
+  Returns the list of organizations.
+
+  ## Examples
+
+      iex> list_organizations()
+      [%Organization{}, ...]
+
+  """
+  def list_organizations do
+    Repo.all(Organization)
+  end
+
+  @doc """
+  Gets a single organization.
+
+  Raises `Ecto.NoResultsError` if the Organization does not exist.
+
+  ## Examples
+
+      iex> get_organization!(123)
+      %Organization{}
+
+      iex> get_organization!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_organization!(id), do: Repo.get!(Organization, id)
+
+  @doc """
+  Creates a organization.
+
+  ## Examples
+
+      iex> create_organization(%{field: value})
+      {:ok, %Organization{}}
+
+      iex> create_organization(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_organization(attrs \\ %{}) do
+    %Organization{}
+    |> Organization.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a organization.
+
+  ## Examples
+
+      iex> update_organization(organization, %{field: new_value})
+      {:ok, %Organization{}}
+
+      iex> update_organization(organization, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_organization(%Organization{} = organization, attrs) do
+    organization
+    |> Organization.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a organization.
+
+  ## Examples
+
+      iex> delete_organization(organization)
+      {:ok, %Organization{}}
+
+      iex> delete_organization(organization)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_organization(%Organization{} = organization) do
+    Repo.delete(organization)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking organization changes.
+
+  ## Examples
+
+      iex> change_organization(organization)
+      %Ecto.Changeset{data: %Organization{}}
+
+  """
+  def change_organization(%Organization{} = organization, attrs \\ %{}) do
+    Organization.changeset(organization, attrs)
+  end
+end

--- a/lib/organization_api/organizations/organization.ex
+++ b/lib/organization_api/organizations/organization.ex
@@ -1,0 +1,21 @@
+defmodule OrganizationApi.Organizations.Organization do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "organizations" do
+    field :name, :string
+    field :logo_url, :string
+    field :configurations, :map
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(organization, attrs) do
+    organization
+    |> cast(attrs, [:name, :logo_url, :configurations])
+    |> validate_required([:name, :logo_url])
+  end
+end

--- a/lib/organization_api_web/controllers/changeset_json.ex
+++ b/lib/organization_api_web/controllers/changeset_json.ex
@@ -1,0 +1,25 @@
+defmodule OrganizationApiWeb.ChangesetJSON do
+  @doc """
+  Renders changeset errors.
+  """
+  def error(%{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)}
+  end
+
+  defp translate_error({msg, opts}) do
+    # You can make use of gettext to translate error messages by
+    # uncommenting and adjusting the following code:
+
+    # if count = opts[:count] do
+    #   Gettext.dngettext(OrganizationApiWeb.Gettext, "errors", msg, msg, count, opts)
+    # else
+    #   Gettext.dgettext(OrganizationApiWeb.Gettext, "errors", msg, opts)
+    # end
+
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end
+end

--- a/lib/organization_api_web/controllers/fallback_controller.ex
+++ b/lib/organization_api_web/controllers/fallback_controller.ex
@@ -1,0 +1,24 @@
+defmodule OrganizationApiWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use OrganizationApiWeb, :controller
+
+  # This clause handles errors returned by Ecto's insert/update/delete.
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: OrganizationApiWeb.ChangesetJSON)
+    |> render(:error, changeset: changeset)
+  end
+
+  # This clause is an example of how to handle resources that cannot be found.
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(html: OrganizationApiWeb.ErrorHTML, json: OrganizationApiWeb.ErrorJSON)
+    |> render(:"404")
+  end
+end

--- a/lib/organization_api_web/controllers/organization_controller.ex
+++ b/lib/organization_api_web/controllers/organization_controller.ex
@@ -1,0 +1,43 @@
+defmodule OrganizationApiWeb.OrganizationController do
+  use OrganizationApiWeb, :controller
+
+  alias OrganizationApi.Organizations
+  alias OrganizationApi.Organizations.Organization
+
+  action_fallback OrganizationApiWeb.FallbackController
+
+  def index(conn, _params) do
+    organizations = Organizations.list_organizations()
+    render(conn, :index, organizations: organizations)
+  end
+
+  def create(conn, %{"organization" => organization_params}) do
+    with {:ok, %Organization{} = organization} <- Organizations.create_organization(organization_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/organizations/#{organization}")
+      |> render(:show, organization: organization)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    organization = Organizations.get_organization!(id)
+    render(conn, :show, organization: organization)
+  end
+
+  def update(conn, %{"id" => id, "organization" => organization_params}) do
+    organization = Organizations.get_organization!(id)
+
+    with {:ok, %Organization{} = organization} <- Organizations.update_organization(organization, organization_params) do
+      render(conn, :show, organization: organization)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    organization = Organizations.get_organization!(id)
+
+    with {:ok, %Organization{}} <- Organizations.delete_organization(organization) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/organization_api_web/controllers/organization_json.ex
+++ b/lib/organization_api_web/controllers/organization_json.ex
@@ -1,0 +1,26 @@
+defmodule OrganizationApiWeb.OrganizationJSON do
+  alias OrganizationApi.Organizations.Organization
+
+  @doc """
+  Renders a list of organizations.
+  """
+  def index(%{organizations: organizations}) do
+    %{data: for(organization <- organizations, do: data(organization))}
+  end
+
+  @doc """
+  Renders a single organization.
+  """
+  def show(%{organization: organization}) do
+    %{data: data(organization)}
+  end
+
+  defp data(%Organization{} = organization) do
+    %{
+      id: organization.id,
+      name: organization.name,
+      logo_url: organization.logo_url,
+      configurations: organization.configurations
+    }
+  end
+end

--- a/lib/organization_api_web/router.ex
+++ b/lib/organization_api_web/router.ex
@@ -7,5 +7,6 @@ defmodule OrganizationApiWeb.Router do
 
   scope "/api", OrganizationApiWeb do
     pipe_through :api
+    resources "/organizations", OrganizationController, except: [:new, :edit]
   end
 end

--- a/priv/repo/migrations/20240613155921_create_organizations.exs
+++ b/priv/repo/migrations/20240613155921_create_organizations.exs
@@ -1,0 +1,14 @@
+defmodule OrganizationApi.Repo.Migrations.CreateOrganizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:organizations, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :logo_url, :string
+      add :configurations, :map
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/test/organization_api/organizations_test.exs
+++ b/test/organization_api/organizations_test.exs
@@ -1,0 +1,63 @@
+defmodule OrganizationApi.OrganizationsTest do
+  use OrganizationApi.DataCase
+
+  alias OrganizationApi.Organizations
+
+  describe "organizations" do
+    alias OrganizationApi.Organizations.Organization
+
+    import OrganizationApi.OrganizationsFixtures
+
+    @invalid_attrs %{name: nil, logo_url: nil, configurations: nil}
+
+    test "list_organizations/0 returns all organizations" do
+      organization = organization_fixture()
+      assert Organizations.list_organizations() == [organization]
+    end
+
+    test "get_organization!/1 returns the organization with given id" do
+      organization = organization_fixture()
+      assert Organizations.get_organization!(organization.id) == organization
+    end
+
+    test "create_organization/1 with valid data creates a organization" do
+      valid_attrs = %{name: "some name", logo_url: "some logo_url", configurations: %{}}
+
+      assert {:ok, %Organization{} = organization} = Organizations.create_organization(valid_attrs)
+      assert organization.name == "some name"
+      assert organization.logo_url == "some logo_url"
+      assert organization.configurations == %{}
+    end
+
+    test "create_organization/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Organizations.create_organization(@invalid_attrs)
+    end
+
+    test "update_organization/2 with valid data updates the organization" do
+      organization = organization_fixture()
+      update_attrs = %{name: "some updated name", logo_url: "some updated logo_url", configurations: %{}}
+
+      assert {:ok, %Organization{} = organization} = Organizations.update_organization(organization, update_attrs)
+      assert organization.name == "some updated name"
+      assert organization.logo_url == "some updated logo_url"
+      assert organization.configurations == %{}
+    end
+
+    test "update_organization/2 with invalid data returns error changeset" do
+      organization = organization_fixture()
+      assert {:error, %Ecto.Changeset{}} = Organizations.update_organization(organization, @invalid_attrs)
+      assert organization == Organizations.get_organization!(organization.id)
+    end
+
+    test "delete_organization/1 deletes the organization" do
+      organization = organization_fixture()
+      assert {:ok, %Organization{}} = Organizations.delete_organization(organization)
+      assert_raise Ecto.NoResultsError, fn -> Organizations.get_organization!(organization.id) end
+    end
+
+    test "change_organization/1 returns a organization changeset" do
+      organization = organization_fixture()
+      assert %Ecto.Changeset{} = Organizations.change_organization(organization)
+    end
+  end
+end

--- a/test/organization_api_web/controllers/organization_controller_test.exs
+++ b/test/organization_api_web/controllers/organization_controller_test.exs
@@ -1,0 +1,92 @@
+defmodule OrganizationApiWeb.OrganizationControllerTest do
+  use OrganizationApiWeb.ConnCase
+
+  import OrganizationApi.OrganizationsFixtures
+
+  alias OrganizationApi.Organizations.Organization
+
+  @create_attrs %{
+    name: "some name",
+    logo_url: "some logo_url",
+    configurations: %{}
+  }
+  @update_attrs %{
+    name: "some updated name",
+    logo_url: "some updated logo_url",
+    configurations: %{}
+  }
+  @invalid_attrs %{name: nil, logo_url: nil, configurations: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all organizations", %{conn: conn} do
+      conn = get(conn, ~p"/api/organizations")
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create organization" do
+    test "renders organization when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/api/organizations", organization: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, ~p"/api/organizations/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "configurations" => %{},
+               "logo_url" => "some logo_url",
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/api/organizations", organization: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update organization" do
+    setup [:create_organization]
+
+    test "renders organization when data is valid", %{conn: conn, organization: %Organization{id: id} = organization} do
+      conn = put(conn, ~p"/api/organizations/#{organization}", organization: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, ~p"/api/organizations/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "configurations" => %{},
+               "logo_url" => "some updated logo_url",
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, organization: organization} do
+      conn = put(conn, ~p"/api/organizations/#{organization}", organization: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete organization" do
+    setup [:create_organization]
+
+    test "deletes chosen organization", %{conn: conn, organization: organization} do
+      conn = delete(conn, ~p"/api/organizations/#{organization}")
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/api/organizations/#{organization}")
+      end
+    end
+  end
+
+  defp create_organization(_) do
+    organization = organization_fixture()
+    %{organization: organization}
+  end
+end

--- a/test/support/fixtures/organizations_fixtures.ex
+++ b/test/support/fixtures/organizations_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule OrganizationApi.OrganizationsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `OrganizationApi.Organizations` context.
+  """
+
+  @doc """
+  Generate a organization.
+  """
+  def organization_fixture(attrs \\ %{}) do
+    {:ok, organization} =
+      attrs
+      |> Enum.into(%{
+        configurations: %{},
+        logo_url: "some logo_url",
+        name: "some name"
+      })
+      |> OrganizationApi.Organizations.create_organization()
+
+    organization
+  end
+end


### PR DESCRIPTION

### Overview

This PR adds CRUD functionality for organization API and test for the controllers.
Changes Made

- Created the migration to set up Organization table.
- Created routes for the organization API.
- Implemented Create functionality for the Organization endpoint.
- Implemented Read functionality for the Organization endpoint.
- Implemented Update functionality for the Organization endpoint.
- Implemented Delete functionality for the Organization endpoint.
- Wrote tests for the Organizations context and the associated controller.

