### PR TITLE
Feat/2 create endpoint for vendors

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -26,6 +26,6 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :phoenix_live_view,
+# config :phoenix_live_view,
   # Enable helpful, but potentially expensive runtime checks
-  enable_expensive_runtime_checks: true
+  # enable_expensive_runtime_checks: true

--- a/lib/organization_api/handle_error.ex
+++ b/lib/organization_api/handle_error.ex
@@ -1,0 +1,6 @@
+defmodule OrganizationApi.HandleError do
+
+  def handle_repo_result({:ok, result}, _error_message), do: {:ok, result}
+  def handle_repo_result({:error, %Ecto.Changeset{} = changeset}, _error_message), do: {:error, changeset}
+  def handle_repo_result({:error, _reason}, error_message), do: {:error, error_message}
+end

--- a/lib/organization_api/organizations.ex
+++ b/lib/organization_api/organizations.ex
@@ -4,8 +4,9 @@ defmodule OrganizationApi.Organizations do
   """
 
   import Ecto.Query, warn: false
-  alias OrganizationApi.Repo
+  import OrganizationApi.HandleError
 
+  alias OrganizationApi.Repo
   alias OrganizationApi.Organizations.Organization
 
   @doc """
@@ -106,8 +107,4 @@ defmodule OrganizationApi.Organizations do
     Organization.changeset(organization, attrs)
   end
 
-  defp handle_repo_result({:ok, result}, _error_message), do: {:ok, result}
-  defp handle_repo_result({:error, %Ecto.Changeset{} = changeset}, _error_message), do: {:error, changeset}
-  defp handle_repo_result({:error, _reason}, error_message), do: {:error, error_message}
-  defp handle_repo_result(nil, error_message), do: {:error, error_message}
 end

--- a/lib/organization_api/organizations.ex
+++ b/lib/organization_api/organizations.ex
@@ -53,6 +53,7 @@ defmodule OrganizationApi.Organizations do
     %Organization{}
     |> Organization.changeset(attrs)
     |> Repo.insert()
+    |> handle_repo_result("Unable to create the organization.")
   end
 
   @doc """
@@ -71,6 +72,7 @@ defmodule OrganizationApi.Organizations do
     organization
     |> Organization.changeset(attrs)
     |> Repo.update()
+    |> handle_repo_result("Unable to update the organization.")
   end
 
   @doc """
@@ -86,7 +88,9 @@ defmodule OrganizationApi.Organizations do
 
   """
   def delete_organization(%Organization{} = organization) do
-    Repo.delete(organization)
+    organization
+    |> Repo.delete()
+    |> handle_repo_result("Unable to delete the organization.")
   end
 
   @doc """
@@ -101,4 +105,9 @@ defmodule OrganizationApi.Organizations do
   def change_organization(%Organization{} = organization, attrs \\ %{}) do
     Organization.changeset(organization, attrs)
   end
+
+  defp handle_repo_result({:ok, result}, _error_message), do: {:ok, result}
+  defp handle_repo_result({:error, %Ecto.Changeset{} = changeset}, _error_message), do: {:error, changeset}
+  defp handle_repo_result({:error, _reason}, error_message), do: {:error, error_message}
+  defp handle_repo_result(nil, error_message), do: {:error, error_message}
 end

--- a/lib/organization_api/organizations/organization.ex
+++ b/lib/organization_api/organizations/organization.ex
@@ -8,7 +8,7 @@ defmodule OrganizationApi.Organizations.Organization do
     field :name, :string
     field :logo_url, :string
     field :configurations, :map
-
+    has_many :vendors , OrganizationApi.Vendors.Vendor
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/organization_api/vendors.ex
+++ b/lib/organization_api/vendors.ex
@@ -53,6 +53,7 @@ defmodule OrganizationApi.Vendors do
     %Vendor{}
     |> Vendor.changeset(attrs)
     |> Repo.insert()
+    |> handle_repo_result("Unable to create the vendor")
   end
 
   @doc """
@@ -71,6 +72,7 @@ defmodule OrganizationApi.Vendors do
     vendor
     |> Vendor.changeset(attrs)
     |> Repo.update()
+    |> handle_repo_result("Unable to update the vendor")
   end
 
   @doc """
@@ -86,7 +88,9 @@ defmodule OrganizationApi.Vendors do
 
   """
   def delete_vendor(%Vendor{} = vendor) do
-    Repo.delete(vendor)
+    vendor
+    |> Repo.delete()
+    |> handle_repo_result("Unable to delete the vendor")
   end
 
   @doc """
@@ -101,4 +105,9 @@ defmodule OrganizationApi.Vendors do
   def change_vendor(%Vendor{} = vendor, attrs \\ %{}) do
     Vendor.changeset(vendor, attrs)
   end
+
+  defp handle_repo_result({:ok, result}, _error_message), do: {:ok, result}
+  defp handle_repo_result({:error, %Ecto.Changeset{} = changeset}, _error_message), do: {:error, changeset}
+  defp handle_repo_result({:error, _reason}, error_message), do: {:error, error_message}
+  defp handle_repo_result(nil, error_message), do: {:error, error_message}
 end

--- a/lib/organization_api/vendors.ex
+++ b/lib/organization_api/vendors.ex
@@ -4,6 +4,8 @@ defmodule OrganizationApi.Vendors do
   """
 
   import Ecto.Query, warn: false
+  import OrganizationApi.HandleError
+
   alias OrganizationApi.Repo
 
   alias OrganizationApi.Vendors.Vendor
@@ -106,8 +108,4 @@ defmodule OrganizationApi.Vendors do
     Vendor.changeset(vendor, attrs)
   end
 
-  defp handle_repo_result({:ok, result}, _error_message), do: {:ok, result}
-  defp handle_repo_result({:error, %Ecto.Changeset{} = changeset}, _error_message), do: {:error, changeset}
-  defp handle_repo_result({:error, _reason}, error_message), do: {:error, error_message}
-  defp handle_repo_result(nil, error_message), do: {:error, error_message}
 end

--- a/lib/organization_api/vendors.ex
+++ b/lib/organization_api/vendors.ex
@@ -1,0 +1,104 @@
+defmodule OrganizationApi.Vendors do
+  @moduledoc """
+  The Vendors context.
+  """
+
+  import Ecto.Query, warn: false
+  alias OrganizationApi.Repo
+
+  alias OrganizationApi.Vendors.Vendor
+
+  @doc """
+  Returns the list of vendors.
+
+  ## Examples
+
+      iex> list_vendors()
+      [%Vendor{}, ...]
+
+  """
+  def list_vendors do
+    Repo.all(Vendor)
+  end
+
+  @doc """
+  Gets a single vendor.
+
+  Raises `Ecto.NoResultsError` if the Vendor does not exist.
+
+  ## Examples
+
+      iex> get_vendor!(123)
+      %Vendor{}
+
+      iex> get_vendor!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_vendor!(id), do: Repo.get!(Vendor, id)
+
+  @doc """
+  Creates a vendor.
+
+  ## Examples
+
+      iex> create_vendor(%{field: value})
+      {:ok, %Vendor{}}
+
+      iex> create_vendor(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_vendor(attrs \\ %{}) do
+    %Vendor{}
+    |> Vendor.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a vendor.
+
+  ## Examples
+
+      iex> update_vendor(vendor, %{field: new_value})
+      {:ok, %Vendor{}}
+
+      iex> update_vendor(vendor, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_vendor(%Vendor{} = vendor, attrs) do
+    vendor
+    |> Vendor.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a vendor.
+
+  ## Examples
+
+      iex> delete_vendor(vendor)
+      {:ok, %Vendor{}}
+
+      iex> delete_vendor(vendor)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_vendor(%Vendor{} = vendor) do
+    Repo.delete(vendor)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking vendor changes.
+
+  ## Examples
+
+      iex> change_vendor(vendor)
+      %Ecto.Changeset{data: %Vendor{}}
+
+  """
+  def change_vendor(%Vendor{} = vendor, attrs \\ %{}) do
+    Vendor.changeset(vendor, attrs)
+  end
+end

--- a/lib/organization_api/vendors/vendor.ex
+++ b/lib/organization_api/vendors/vendor.ex
@@ -17,7 +17,7 @@ defmodule OrganizationApi.Vendors.Vendor do
   def changeset(vendor, attrs) do
     vendor
     |> cast(attrs, [:name, :phone, :email, :organization_id])
-    |> validate_required([:name, :phone, :email, :organization_id])
+    |> validate_required([:name, :organization_id])
     |> unique_constraint(:name)
     |> assoc_constraint(:organization)
   end

--- a/lib/organization_api/vendors/vendor.ex
+++ b/lib/organization_api/vendors/vendor.ex
@@ -1,0 +1,23 @@
+defmodule OrganizationApi.Vendors.Vendor do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "vendors" do
+    field :name, :string
+    field :phone, :string
+    field :email, :string
+    field :organization_id, :binary_id
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(vendor, attrs) do
+    vendor
+    |> cast(attrs, [:name, :phone, :email])
+    |> validate_required([:name, :phone, :email])
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/organization_api/vendors/vendor.ex
+++ b/lib/organization_api/vendors/vendor.ex
@@ -8,7 +8,7 @@ defmodule OrganizationApi.Vendors.Vendor do
     field :name, :string
     field :phone, :string
     field :email, :string
-    field :organization_id, :binary_id
+    belongs_to :organization, OrganizationApi.Organizations.Organization
 
     timestamps(type: :utc_datetime)
   end
@@ -16,8 +16,9 @@ defmodule OrganizationApi.Vendors.Vendor do
   @doc false
   def changeset(vendor, attrs) do
     vendor
-    |> cast(attrs, [:name, :phone, :email])
-    |> validate_required([:name, :phone, :email])
+    |> cast(attrs, [:name, :phone, :email, :organization_id])
+    |> validate_required([:name, :phone, :email, :organization_id])
     |> unique_constraint(:name)
+    |> assoc_constraint(:organization)
   end
 end

--- a/lib/organization_api_web/controllers/fallback_controller.ex
+++ b/lib/organization_api_web/controllers/fallback_controller.ex
@@ -21,4 +21,11 @@ defmodule OrganizationApiWeb.FallbackController do
     |> put_view(html: OrganizationApiWeb.ErrorHTML, json: OrganizationApiWeb.ErrorJSON)
     |> render(:"404")
   end
+
+  def call(conn, {:error, message}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: message})
+  end
+
 end

--- a/lib/organization_api_web/controllers/organization_json.ex
+++ b/lib/organization_api_web/controllers/organization_json.ex
@@ -5,14 +5,14 @@ defmodule OrganizationApiWeb.OrganizationJSON do
   Renders a list of organizations.
   """
   def index(%{organizations: organizations}) do
-    %{data: for(organization <- organizations, do: data(organization))}
+    for(organization <- organizations, do: data(organization))
   end
 
   @doc """
   Renders a single organization.
   """
   def show(%{organization: organization}) do
-    %{data: data(organization)}
+    data(organization)
   end
 
   defp data(%Organization{} = organization) do

--- a/lib/organization_api_web/controllers/vendor_controller.ex
+++ b/lib/organization_api_web/controllers/vendor_controller.ex
@@ -1,0 +1,43 @@
+defmodule OrganizationApiWeb.VendorController do
+  use OrganizationApiWeb, :controller
+
+  alias OrganizationApi.Vendors
+  alias OrganizationApi.Vendors.Vendor
+
+  action_fallback OrganizationApiWeb.FallbackController
+
+  def index(conn, _params) do
+    vendors = Vendors.list_vendors()
+    render(conn, :index, vendors: vendors)
+  end
+
+  def create(conn, %{"vendor" => vendor_params}) do
+    with {:ok, %Vendor{} = vendor} <- Vendors.create_vendor(vendor_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/vendors/#{vendor}")
+      |> render(:show, vendor: vendor)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    vendor = Vendors.get_vendor!(id)
+    render(conn, :show, vendor: vendor)
+  end
+
+  def update(conn, %{"id" => id, "vendor" => vendor_params}) do
+    vendor = Vendors.get_vendor!(id)
+
+    with {:ok, %Vendor{} = vendor} <- Vendors.update_vendor(vendor, vendor_params) do
+      render(conn, :show, vendor: vendor)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    vendor = Vendors.get_vendor!(id)
+
+    with {:ok, %Vendor{}} <- Vendors.delete_vendor(vendor) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/organization_api_web/controllers/vendor_json.ex
+++ b/lib/organization_api_web/controllers/vendor_json.ex
@@ -1,0 +1,26 @@
+defmodule OrganizationApiWeb.VendorJSON do
+  alias OrganizationApi.Vendors.Vendor
+
+  @doc """
+  Renders a list of vendors.
+  """
+  def index(%{vendors: vendors}) do
+    %{data: for(vendor <- vendors, do: data(vendor))}
+  end
+
+  @doc """
+  Renders a single vendor.
+  """
+  def show(%{vendor: vendor}) do
+    %{data: data(vendor)}
+  end
+
+  defp data(%Vendor{} = vendor) do
+    %{
+      id: vendor.id,
+      name: vendor.name,
+      phone: vendor.phone,
+      email: vendor.email
+    }
+  end
+end

--- a/lib/organization_api_web/controllers/vendor_json.ex
+++ b/lib/organization_api_web/controllers/vendor_json.ex
@@ -5,14 +5,14 @@ defmodule OrganizationApiWeb.VendorJSON do
   Renders a list of vendors.
   """
   def index(%{vendors: vendors}) do
-    %{data: for(vendor <- vendors, do: data(vendor))}
+    for(vendor <- vendors, do: data(vendor))
   end
 
   @doc """
   Renders a single vendor.
   """
   def show(%{vendor: vendor}) do
-    %{data: data(vendor)}
+    data(vendor)
   end
 
   defp data(%Vendor{} = vendor) do

--- a/lib/organization_api_web/router.ex
+++ b/lib/organization_api_web/router.ex
@@ -8,5 +8,6 @@ defmodule OrganizationApiWeb.Router do
   scope "/api", OrganizationApiWeb do
     pipe_through :api
     resources "/organizations", OrganizationController, except: [:new, :edit]
+    resources "/vendors", VendorController, except: [:new, :edit]
   end
 end

--- a/priv/repo/migrations/20240616084818_create_vendors.exs
+++ b/priv/repo/migrations/20240616084818_create_vendors.exs
@@ -1,0 +1,18 @@
+defmodule OrganizationApi.Repo.Migrations.CreateVendors do
+  use Ecto.Migration
+
+  def change do
+    create table(:vendors, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :phone, :string
+      add :email, :string
+      add :organization_id, references(:organizations, on_delete: :nothing, type: :binary_id)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:vendors, [:name])
+    create index(:vendors, [:organization_id])
+  end
+end

--- a/test/organization_api/vendors_test.exs
+++ b/test/organization_api/vendors_test.exs
@@ -10,18 +10,23 @@ defmodule OrganizationApi.VendorsTest do
 
     @invalid_attrs %{name: nil, phone: nil, email: nil}
 
-    test "list_vendors/0 returns all vendors" do
-      vendor = vendor_fixture()
+    setup do
+      organization = OrganizationApi.OrganizationsFixtures.organization_fixture()
+      {:ok, organization: organization}
+    end
+
+    test "list_vendors/0 returns all vendors",%{organization: organization} do
+      vendor = vendor_fixture(%{organization_id: organization.id})
       assert Vendors.list_vendors() == [vendor]
     end
 
-    test "get_vendor!/1 returns the vendor with given id" do
-      vendor = vendor_fixture()
+    test "get_vendor!/1 returns the vendor with given id", %{organization: organization} do
+      vendor = vendor_fixture(%{organization_id: organization.id})
       assert Vendors.get_vendor!(vendor.id) == vendor
     end
 
-    test "create_vendor/1 with valid data creates a vendor" do
-      valid_attrs = %{name: "some name", phone: "some phone", email: "some email"}
+    test "create_vendor/1 with valid data creates a vendor", %{organization: organization} do
+      valid_attrs = %{name: "some name", phone: "some phone", email: "some email", organization_id: organization.id }
 
       assert {:ok, %Vendor{} = vendor} = Vendors.create_vendor(valid_attrs)
       assert vendor.name == "some name"
@@ -33,9 +38,9 @@ defmodule OrganizationApi.VendorsTest do
       assert {:error, %Ecto.Changeset{}} = Vendors.create_vendor(@invalid_attrs)
     end
 
-    test "update_vendor/2 with valid data updates the vendor" do
+    test "update_vendor/2 with valid data updates the vendor", %{organization: organization} do
       vendor = vendor_fixture()
-      update_attrs = %{name: "some updated name", phone: "some updated phone", email: "some updated email"}
+      update_attrs = %{name: "some updated name", phone: "some updated phone", email: "some updated email", organization_id: organization.id}
 
       assert {:ok, %Vendor{} = vendor} = Vendors.update_vendor(vendor, update_attrs)
       assert vendor.name == "some updated name"
@@ -43,20 +48,20 @@ defmodule OrganizationApi.VendorsTest do
       assert vendor.email == "some updated email"
     end
 
-    test "update_vendor/2 with invalid data returns error changeset" do
-      vendor = vendor_fixture()
+    test "update_vendor/2 with invalid data returns error changeset",%{organization: organization} do
+      vendor = vendor_fixture(%{organization_id: organization.id})
       assert {:error, %Ecto.Changeset{}} = Vendors.update_vendor(vendor, @invalid_attrs)
       assert vendor == Vendors.get_vendor!(vendor.id)
     end
 
-    test "delete_vendor/1 deletes the vendor" do
-      vendor = vendor_fixture()
+    test "delete_vendor/1 deletes the vendor", %{organization: organization} do
+      vendor = vendor_fixture(%{organization_id: organization.id})
       assert {:ok, %Vendor{}} = Vendors.delete_vendor(vendor)
       assert_raise Ecto.NoResultsError, fn -> Vendors.get_vendor!(vendor.id) end
     end
 
-    test "change_vendor/1 returns a vendor changeset" do
-      vendor = vendor_fixture()
+    test "change_vendor/1 returns a vendor changeset", %{organization: organization} do
+      vendor = vendor_fixture(%{organization_id: organization.id})
       assert %Ecto.Changeset{} = Vendors.change_vendor(vendor)
     end
   end

--- a/test/organization_api/vendors_test.exs
+++ b/test/organization_api/vendors_test.exs
@@ -1,0 +1,63 @@
+defmodule OrganizationApi.VendorsTest do
+  use OrganizationApi.DataCase
+
+  alias OrganizationApi.Vendors
+
+  describe "vendors" do
+    alias OrganizationApi.Vendors.Vendor
+
+    import OrganizationApi.VendorsFixtures
+
+    @invalid_attrs %{name: nil, phone: nil, email: nil}
+
+    test "list_vendors/0 returns all vendors" do
+      vendor = vendor_fixture()
+      assert Vendors.list_vendors() == [vendor]
+    end
+
+    test "get_vendor!/1 returns the vendor with given id" do
+      vendor = vendor_fixture()
+      assert Vendors.get_vendor!(vendor.id) == vendor
+    end
+
+    test "create_vendor/1 with valid data creates a vendor" do
+      valid_attrs = %{name: "some name", phone: "some phone", email: "some email"}
+
+      assert {:ok, %Vendor{} = vendor} = Vendors.create_vendor(valid_attrs)
+      assert vendor.name == "some name"
+      assert vendor.phone == "some phone"
+      assert vendor.email == "some email"
+    end
+
+    test "create_vendor/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Vendors.create_vendor(@invalid_attrs)
+    end
+
+    test "update_vendor/2 with valid data updates the vendor" do
+      vendor = vendor_fixture()
+      update_attrs = %{name: "some updated name", phone: "some updated phone", email: "some updated email"}
+
+      assert {:ok, %Vendor{} = vendor} = Vendors.update_vendor(vendor, update_attrs)
+      assert vendor.name == "some updated name"
+      assert vendor.phone == "some updated phone"
+      assert vendor.email == "some updated email"
+    end
+
+    test "update_vendor/2 with invalid data returns error changeset" do
+      vendor = vendor_fixture()
+      assert {:error, %Ecto.Changeset{}} = Vendors.update_vendor(vendor, @invalid_attrs)
+      assert vendor == Vendors.get_vendor!(vendor.id)
+    end
+
+    test "delete_vendor/1 deletes the vendor" do
+      vendor = vendor_fixture()
+      assert {:ok, %Vendor{}} = Vendors.delete_vendor(vendor)
+      assert_raise Ecto.NoResultsError, fn -> Vendors.get_vendor!(vendor.id) end
+    end
+
+    test "change_vendor/1 returns a vendor changeset" do
+      vendor = vendor_fixture()
+      assert %Ecto.Changeset{} = Vendors.change_vendor(vendor)
+    end
+  end
+end

--- a/test/organization_api/vendors_test.exs
+++ b/test/organization_api/vendors_test.exs
@@ -2,31 +2,26 @@ defmodule OrganizationApi.VendorsTest do
   use OrganizationApi.DataCase
 
   alias OrganizationApi.Vendors
+  alias OrganizationApi.Vendors.Vendor
+
+  import OrganizationApi.VendorsFixtures
+  import OrganizationApi.OrganizationsFixtures
+
+  @invalid_attrs %{name: nil, phone: nil, email: nil}
 
   describe "vendors" do
-    alias OrganizationApi.Vendors.Vendor
-
-    import OrganizationApi.VendorsFixtures
-
-    @invalid_attrs %{name: nil, phone: nil, email: nil}
-
-    setup do
-      organization = OrganizationApi.OrganizationsFixtures.organization_fixture()
-      {:ok, organization: organization}
-    end
-
-    test "list_vendors/0 returns all vendors",%{organization: organization} do
-      vendor = vendor_fixture(%{organization_id: organization.id})
+    test "list_vendors/0 returns all vendors" do
+      vendor = vendor_fixture()
       assert Vendors.list_vendors() == [vendor]
     end
 
-    test "get_vendor!/1 returns the vendor with given id", %{organization: organization} do
-      vendor = vendor_fixture(%{organization_id: organization.id})
+    test "get_vendor!/1 returns the vendor with given id" do
+      vendor = vendor_fixture()
       assert Vendors.get_vendor!(vendor.id) == vendor
     end
 
-    test "create_vendor/1 with valid data creates a vendor", %{organization: organization} do
-      valid_attrs = %{name: "some name", phone: "some phone", email: "some email", organization_id: organization.id }
+    test "create_vendor/1 with valid data creates a vendor" do
+      valid_attrs = %{name: "some name", phone: "some phone", email: "some email", organization_id: organization_fixture().id }
 
       assert {:ok, %Vendor{} = vendor} = Vendors.create_vendor(valid_attrs)
       assert vendor.name == "some name"
@@ -38,9 +33,9 @@ defmodule OrganizationApi.VendorsTest do
       assert {:error, %Ecto.Changeset{}} = Vendors.create_vendor(@invalid_attrs)
     end
 
-    test "update_vendor/2 with valid data updates the vendor", %{organization: organization} do
+    test "update_vendor/2 with valid data updates the vendor" do
       vendor = vendor_fixture()
-      update_attrs = %{name: "some updated name", phone: "some updated phone", email: "some updated email", organization_id: organization.id}
+      update_attrs = %{name: "some updated name", phone: "some updated phone", email: "some updated email"}
 
       assert {:ok, %Vendor{} = vendor} = Vendors.update_vendor(vendor, update_attrs)
       assert vendor.name == "some updated name"
@@ -48,20 +43,20 @@ defmodule OrganizationApi.VendorsTest do
       assert vendor.email == "some updated email"
     end
 
-    test "update_vendor/2 with invalid data returns error changeset",%{organization: organization} do
-      vendor = vendor_fixture(%{organization_id: organization.id})
+    test "update_vendor/2 with invalid data returns error changeset" do
+      vendor = vendor_fixture()
       assert {:error, %Ecto.Changeset{}} = Vendors.update_vendor(vendor, @invalid_attrs)
       assert vendor == Vendors.get_vendor!(vendor.id)
     end
 
-    test "delete_vendor/1 deletes the vendor", %{organization: organization} do
-      vendor = vendor_fixture(%{organization_id: organization.id})
+    test "delete_vendor/1 deletes the vendor" do
+      vendor = vendor_fixture()
       assert {:ok, %Vendor{}} = Vendors.delete_vendor(vendor)
       assert_raise Ecto.NoResultsError, fn -> Vendors.get_vendor!(vendor.id) end
     end
 
-    test "change_vendor/1 returns a vendor changeset", %{organization: organization} do
-      vendor = vendor_fixture(%{organization_id: organization.id})
+    test "change_vendor/1 returns a vendor changeset" do
+      vendor = vendor_fixture()
       assert %Ecto.Changeset{} = Vendors.change_vendor(vendor)
     end
   end

--- a/test/organization_api_web/controllers/organization_controller_test.exs
+++ b/test/organization_api_web/controllers/organization_controller_test.exs
@@ -24,14 +24,14 @@ defmodule OrganizationApiWeb.OrganizationControllerTest do
   describe "index" do
     test "lists all organizations", %{conn: conn} do
       conn = get(conn, ~p"/api/organizations")
-      assert json_response(conn, 200)["data"] == []
+      assert json_response(conn, 200) == []
     end
   end
 
   describe "create organization" do
     test "renders organization when data is valid", %{conn: conn} do
       conn = post(conn, ~p"/api/organizations", organization: @create_attrs)
-      assert %{"id" => id} = json_response(conn, 201)["data"]
+      assert %{"id" => id} = json_response(conn, 201)
 
       conn = get(conn, ~p"/api/organizations/#{id}")
 
@@ -40,7 +40,7 @@ defmodule OrganizationApiWeb.OrganizationControllerTest do
                "configurations" => %{},
                "logo_url" => "some logo_url",
                "name" => "some name"
-             } = json_response(conn, 200)["data"]
+             } = json_response(conn, 200)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -54,7 +54,7 @@ defmodule OrganizationApiWeb.OrganizationControllerTest do
 
     test "renders organization when data is valid", %{conn: conn, organization: %Organization{id: id} = organization} do
       conn = put(conn, ~p"/api/organizations/#{organization}", organization: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert %{"id" => ^id} = json_response(conn, 200)
 
       conn = get(conn, ~p"/api/organizations/#{id}")
 
@@ -63,7 +63,7 @@ defmodule OrganizationApiWeb.OrganizationControllerTest do
                "configurations" => %{},
                "logo_url" => "some updated logo_url",
                "name" => "some updated name"
-             } = json_response(conn, 200)["data"]
+             } = json_response(conn, 200)
     end
 
     test "renders errors when data is invalid", %{conn: conn, organization: organization} do

--- a/test/organization_api_web/controllers/vendor_controller_test.exs
+++ b/test/organization_api_web/controllers/vendor_controller_test.exs
@@ -2,7 +2,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
   use OrganizationApiWeb.ConnCase
 
   import OrganizationApi.VendorsFixtures
-
+  import OrganizationApi.OrganizationsFixtures
   alias OrganizationApi.Vendors.Vendor
 
   @create_attrs %{
@@ -29,8 +29,12 @@ defmodule OrganizationApiWeb.VendorControllerTest do
   end
 
   describe "create vendor" do
-    test "renders vendor when data is valid", %{conn: conn} do
-      conn = post(conn, ~p"/api/vendors", vendor: @create_attrs)
+    setup [:create_organization]
+
+    test "renders vendor when data is valid", %{conn: conn, organization: organization} do
+      valid_attrs = Map.put(@create_attrs, :organization_id, organization.id)
+
+      conn = post(conn, ~p"/api/vendors", vendor: valid_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
       conn = get(conn, ~p"/api/vendors/#{id}")
@@ -83,6 +87,11 @@ defmodule OrganizationApiWeb.VendorControllerTest do
         get(conn, ~p"/api/vendors/#{vendor}")
       end
     end
+  end
+
+  defp create_organization(_) do
+    organization = organization_fixture()
+    %{organization: organization}
   end
 
   defp create_vendor(_) do

--- a/test/organization_api_web/controllers/vendor_controller_test.exs
+++ b/test/organization_api_web/controllers/vendor_controller_test.exs
@@ -1,0 +1,92 @@
+defmodule OrganizationApiWeb.VendorControllerTest do
+  use OrganizationApiWeb.ConnCase
+
+  import OrganizationApi.VendorsFixtures
+
+  alias OrganizationApi.Vendors.Vendor
+
+  @create_attrs %{
+    name: "some name",
+    phone: "some phone",
+    email: "some email"
+  }
+  @update_attrs %{
+    name: "some updated name",
+    phone: "some updated phone",
+    email: "some updated email"
+  }
+  @invalid_attrs %{name: nil, phone: nil, email: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all vendors", %{conn: conn} do
+      conn = get(conn, ~p"/api/vendors")
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create vendor" do
+    test "renders vendor when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/api/vendors", vendor: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, ~p"/api/vendors/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "email" => "some email",
+               "name" => "some name",
+               "phone" => "some phone"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/api/vendors", vendor: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update vendor" do
+    setup [:create_vendor]
+
+    test "renders vendor when data is valid", %{conn: conn, vendor: %Vendor{id: id} = vendor} do
+      conn = put(conn, ~p"/api/vendors/#{vendor}", vendor: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, ~p"/api/vendors/#{id}")
+
+      assert %{
+               "id" => ^id,
+               "email" => "some updated email",
+               "name" => "some updated name",
+               "phone" => "some updated phone"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, vendor: vendor} do
+      conn = put(conn, ~p"/api/vendors/#{vendor}", vendor: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete vendor" do
+    setup [:create_vendor]
+
+    test "deletes chosen vendor", %{conn: conn, vendor: vendor} do
+      conn = delete(conn, ~p"/api/vendors/#{vendor}")
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/api/vendors/#{vendor}")
+      end
+    end
+  end
+
+  defp create_vendor(_) do
+    vendor = vendor_fixture()
+    %{vendor: vendor}
+  end
+end

--- a/test/organization_api_web/controllers/vendor_controller_test.exs
+++ b/test/organization_api_web/controllers/vendor_controller_test.exs
@@ -24,7 +24,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
   describe "index" do
     test "lists all vendors", %{conn: conn} do
       conn = get(conn, ~p"/api/vendors")
-      assert json_response(conn, 200)["data"] == []
+      assert json_response(conn, 200) == []
     end
   end
 
@@ -34,7 +34,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
       valid_attrs = Map.put(@create_attrs, :organization_id, organization.id)
 
       conn = post(conn, ~p"/api/vendors", vendor: valid_attrs)
-      assert %{"id" => id} = json_response(conn, 201)["data"]
+      assert %{"id" => id} = json_response(conn, 201)
 
       conn = get(conn, ~p"/api/vendors/#{id}")
 
@@ -43,7 +43,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
                "email" => "some email",
                "name" => "some name",
                "phone" => "some phone"
-             } = json_response(conn, 200)["data"]
+             } = json_response(conn, 200)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -57,7 +57,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
 
     test "renders vendor when data is valid", %{conn: conn, vendor: %Vendor{id: id} = vendor} do
       conn = put(conn, ~p"/api/vendors/#{vendor}", vendor: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      assert %{"id" => ^id} = json_response(conn, 200)
 
       conn = get(conn, ~p"/api/vendors/#{id}")
 
@@ -66,7 +66,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
                "email" => "some updated email",
                "name" => "some updated name",
                "phone" => "some updated phone"
-             } = json_response(conn, 200)["data"]
+             } = json_response(conn, 200)
     end
 
     test "renders errors when data is invalid", %{conn: conn, vendor: vendor} do

--- a/test/organization_api_web/controllers/vendor_controller_test.exs
+++ b/test/organization_api_web/controllers/vendor_controller_test.exs
@@ -18,7 +18,7 @@ defmodule OrganizationApiWeb.VendorControllerTest do
   @invalid_attrs %{name: nil, phone: nil, email: nil}
 
   setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), organization: organization_fixture()}
   end
 
   describe "index" do
@@ -29,7 +29,6 @@ defmodule OrganizationApiWeb.VendorControllerTest do
   end
 
   describe "create vendor" do
-    setup [:create_organization]
 
     test "renders vendor when data is valid", %{conn: conn, organization: organization} do
       valid_attrs = Map.put(@create_attrs, :organization_id, organization.id)
@@ -87,11 +86,6 @@ defmodule OrganizationApiWeb.VendorControllerTest do
         get(conn, ~p"/api/vendors/#{vendor}")
       end
     end
-  end
-
-  defp create_organization(_) do
-    organization = organization_fixture()
-    %{organization: organization}
   end
 
   defp create_vendor(_) do

--- a/test/support/fixtures/vendors_fixtures.ex
+++ b/test/support/fixtures/vendors_fixtures.ex
@@ -1,0 +1,27 @@
+defmodule OrganizationApi.VendorsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `OrganizationApi.Vendors` context.
+  """
+
+  @doc """
+  Generate a unique vendor name.
+  """
+  def unique_vendor_name, do: "some name#{System.unique_integer([:positive])}"
+
+  @doc """
+  Generate a vendor.
+  """
+  def vendor_fixture(attrs \\ %{}) do
+    {:ok, vendor} =
+      attrs
+      |> Enum.into(%{
+        email: "some email",
+        name: unique_vendor_name(),
+        phone: "some phone"
+      })
+      |> OrganizationApi.Vendors.create_vendor()
+
+    vendor
+  end
+end

--- a/test/support/fixtures/vendors_fixtures.ex
+++ b/test/support/fixtures/vendors_fixtures.ex
@@ -1,4 +1,5 @@
 defmodule OrganizationApi.VendorsFixtures do
+  import OrganizationApi.OrganizationsFixtures
   @moduledoc """
   This module defines test helpers for creating
   entities via the `OrganizationApi.Vendors` context.
@@ -13,12 +14,14 @@ defmodule OrganizationApi.VendorsFixtures do
   Generate a vendor.
   """
   def vendor_fixture(attrs \\ %{}) do
+    organization= organization_fixture()
     {:ok, vendor} =
       attrs
       |> Enum.into(%{
         email: "some email",
         name: unique_vendor_name(),
-        phone: "some phone"
+        phone: "some phone",
+        organization_id: organization.id
       })
       |> OrganizationApi.Vendors.create_vendor()
 


### PR DESCRIPTION
### Overview
This PR add vendor endpoint with CRUD functionality to the API.

- Create migration to set up table for vendors.
- Create routes for vendors.
- Create CRUD (Create, Read, Update, Delete) endpoints for vendors API.
- Write tests for vendors context and the associated controller.
- Remove "data" key from JSON response.
- Add a separate module for handling errors for organization and vendor contexts.